### PR TITLE
Dev

### DIFF
--- a/docs/resources/cts_data_tracker.md
+++ b/docs/resources/cts_data_tracker.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Cloud Trace Service (CTS)"
+---
+
+# sbercloud_cts_data_tracker
+
+Manages CTS **data** tracker resource within SberCloud.
+
+## Example Usage
+
+```hcl
+variable "data_bucket" {}
+variable "transfer_bucket" {}
+
+resource "sbercloud_cts_data_tracker" "tracker" {
+  name        = "data-tracker"
+  data_bucket = var.data_bucket
+  bucket_name = var.transfer_bucket
+  file_prefix = "cloudTrace"
+  lts_enabled = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the CTS data tracker resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the data tracker name. The name cannot be system or ststem-trace.
+  Changing this creates a new resource.
+
+* `data_bucket` - (Required, String, ForceNew) Specifies the OBS bucket tracked by the data tracker.
+  Changing this creates a new resource.
+
+* `data_operation` - (Optional, List) Specifies an array of operation types tracked by the data tracker,
+  the value of operation can be **WRITE** or **READ**.
+
+* `bucket_name` - (Optional, String) Specifies the OBS bucket to which traces will be transferred.
+
+* `file_prefix` - (Optional, String) Specifies the file name prefix to mark trace files that need to be stored
+  in an OBS bucket. The value contains 0 to 64 characters. Only letters, numbers, hyphens (-), underscores (_),
+  and periods (.) are allowed.
+
+* `obs_retention_period` - (Optional, Int) Specifies the retention period that traces are stored in `bucket_name`,
+  the value can be **0**(permanent), **30**, **60**, **90**, **180** or **1095**.
+
+* `lts_enabled` - (Optional, Bool) Specifies whether trace analysis is enabled.
+
+* `validate_file` - (Optional, Bool) Specifies whether trace file verification is enabled during trace transfer.
+
+* `enabled` - (Optional, Bool) Specifies whether tracker is enabled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals the tracker name.
+* `type` - The tracker type, only **data** is available.
+* `transfer_enabled` - Whether traces will be transferred.
+* `status` - The tracker status, the value can be **enabled**, **disabled** or **error**.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+CTS data tracker can be imported using `name`, e.g.:
+
+```
+$ terraform import sbercloud_cts_data_tracker.tracker your_tracker_name
+```

--- a/docs/resources/cts_notification.md
+++ b/docs/resources/cts_notification.md
@@ -1,0 +1,104 @@
+---
+subcategory: "Cloud Trace Service (CTS)"
+---
+
+# sbercloud_cts_notification
+
+Manages CTS key event notification resource within SberCloud.
+
+## Example Usage
+
+### Complete Notification
+
+```hcl
+variable "topic_urn" {}
+
+resource "sbercloud_cts_notification" "notify" {
+  name           = "keyOperate_test"
+  operation_type = "complete"
+  smn_topic      = var.topic_urn
+}
+```
+
+### Customized Notification
+
+```hcl
+variable "topic_urn" {}
+
+resource "sbercloud_cts_notification" "notify" {
+  name           = "keyOperate_test"
+  operation_type = "customized"
+  smn_topic      = var.topic_urn
+
+  operations {
+    service     = "ECS"
+    resource    = "ecs"
+    trace_names = ["createServer", "deleteServer"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the CTS notification resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the notification name. The value contains a maximum of 64 characters,
+  and only letters, digits, underscores(_), and Chinese characters are allowed.
+
+* `operation_type` - (Required, String) Specifies the operation type, possible options include **complete** and
+  **customized**.
+
+* `smn_topic` - (Optional, String) Specifies the URN of a topic.
+
+* `operations` - (Optional, List) Specifies an array of operations that will trigger notifications.
+  For details, see [Supported Services and Operations](https://support.sbercloud.com/intl/en-us/usermanual-cts/cts_03_0022.html).
+  The [object](#notification_operations_object) structure is documented below.
+
+* `operation_users` - (Optional, List) Specifies an array of users. Notifications will be sent when specified users
+  perform specified operations. All users are selected by default.
+  The [object](#notification_operation_users_object) structure is documented below.
+
+* `enabled` - (Optional, Bool) Specifies whether notification is enabled, defaults to true.
+
+<a name="notification_operations_object"></a>
+The `operations` block supports:
+
+* `service` - (Required, String) Specifies the cloud service.
+
+* `resource` - (Required, String) Specifies the resource type.
+
+* `trace_names` - (Required, List) Specifies an array of trace names.
+
+<a name="notification_operation_users_object"></a>
+The `operation_users` block supports:
+
+* `group` - (Required, String) Specifies the IAM user group name.
+
+* `users` - (Required, List) Specifies an array of IAM users in the group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals the notification name.
+* `notification_id` - The notification ID in UUID format.
+* `status` - The notification status, the value can be **enabled** or **disabled**.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `update` - Default is 5 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+CTS notifications can be imported using `name`, e.g.:
+
+```
+$ terraform import sbercloud_cts_notification.tracker your_notification
+```

--- a/docs/resources/cts_tracker.md
+++ b/docs/resources/cts_tracker.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Cloud Trace Service (CTS)"
+---
+
+# sbercloud_cts_tracker
+
+Manages CTS **system** tracker resource within SberCloud.
+
+## Example Usage
+
+```hcl
+variable "bucket_name" {}
+
+resource "sbercloud_cts_tracker" "tracker" {
+  bucket_name = var.bucket_name
+  file_prefix = "cts"
+  lts_enabled = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the CTS system tracker resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `bucket_name` - (Optional, String) Specifies the OBS bucket to which traces will be transferred.
+
+* `file_prefix` - (Optional, String) Specifies the file name prefix to mark trace files that need to be stored
+  in an OBS bucket. The value contains 0 to 64 characters. Only letters, numbers, hyphens (-), underscores (_),
+  and periods (.) are allowed.
+
+* `lts_enabled` - (Optional, Bool) Specifies whether trace analysis is enabled.
+
+* `validate_file` - (Optional, Bool) Specifies whether trace file verification is enabled during trace transfer.
+
+* `kms_id` - (Optional, String) Specifies the ID of KMS key used for trace file encryption.
+
+* `enabled` - (Optional, Bool) Specifies whether tracker is enabled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+* `name` - The tracker name, only **system** is available.
+* `type` - The tracker type, only **system** is available.
+* `transfer_enabled` - Whether traces will be transferred.
+* `status` - The tracker status, the value can be **enabled**, **disabled** or **error**.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+CTS tracker can be imported using `name`, only **system** is available. e.g.
+
+```
+$ terraform import sbercloud_cts_tracker.tracker system
+```

--- a/sbercloud/acceptance/cts/resource_sbercloud_cts_data_tracker_test.go
+++ b/sbercloud/acceptance/cts/resource_sbercloud_cts_data_tracker_test.go
@@ -1,0 +1,137 @@
+package cts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+)
+
+func getCTSDataTrackerResourceObj(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcCtsV3Client(acceptance.SBC_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CTS client: %s", err)
+	}
+
+	name := state.Primary.ID
+	trackerType := cts.GetListTrackersRequestTrackerTypeEnum().DATA
+	listOpts := &cts.ListTrackersRequest{
+		TrackerName: &name,
+		TrackerType: &trackerType,
+	}
+
+	response, err := client.ListTrackers(listOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CTS tracker: %s", err)
+	}
+
+	if response.Trackers == nil || len(*response.Trackers) == 0 {
+		return nil, fmt.Errorf("can not find the CTS tracker %s", name)
+	}
+
+	allTrackers := *response.Trackers
+	ctsTracker := allTrackers[0]
+
+	return ctsTracker, nil
+}
+
+func TestAccCTSDataTracker_basic(t *testing.T) {
+	var dataTracker cts.TrackerResponseBody
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "sbercloud_cts_data_tracker.tracker"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&dataTracker,
+		getCTSDataTrackerResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCTSDataTracker_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "transfer_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "type", "data"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "data_operation.#", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "data_bucket",
+						"sbercloud_obs_bucket.data_bucket", "bucket"),
+				),
+			},
+			{
+				Config: testAccCTSDataTracker_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "transfer_enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket_name",
+						"sbercloud_obs_bucket.trans_bucket", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "file_prefix", "cts"),
+					resource.TestCheckResourceAttr(resourceName, "obs_retention_period", "30"),
+					resource.TestCheckResourceAttr(resourceName, "validate_file", "false"),
+					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCTSDataTracker_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_obs_bucket" "data_bucket" {
+  bucket = "%[1]s-data"
+  acl    = "public-read"
+}
+
+resource "sbercloud_cts_data_tracker" "tracker" {
+  name        = "%[1]s"
+  data_bucket = sbercloud_obs_bucket.data_bucket.bucket
+  lts_enabled = true
+}
+`, rName)
+}
+
+func testAccCTSDataTracker_update(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_obs_bucket" "data_bucket" {
+  bucket = "%[1]s-data"
+  acl    = "public-read"
+}
+
+resource "sbercloud_obs_bucket" "trans_bucket" {
+  bucket        = "%[1]s-log"
+  acl           = "private"
+  force_destroy = true
+
+  lifecycle {
+    ignore_changes = [lifecycle_rule]
+  }
+}
+
+resource "sbercloud_cts_data_tracker" "tracker" {
+  name                 = "%[1]s"
+  data_bucket          = sbercloud_obs_bucket.data_bucket.bucket
+  bucket_name          = sbercloud_obs_bucket.trans_bucket.bucket
+  obs_retention_period = 30
+  file_prefix          = "cts"
+  validate_file        = false
+  lts_enabled          = false
+}
+`, rName)
+}

--- a/sbercloud/acceptance/cts/resource_sbercloud_cts_notification_test.go
+++ b/sbercloud/acceptance/cts/resource_sbercloud_cts_notification_test.go
@@ -1,0 +1,151 @@
+package cts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+)
+
+func getCTSNotificationResourceObj(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcCtsV3Client(acceptance.SBC_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CTS client: %s", err)
+	}
+
+	notificationName := state.Primary.ID
+	notificationType := cts.GetListNotificationsRequestNotificationTypeEnum().SMN
+	listOpts := &cts.ListNotificationsRequest{
+		NotificationType: notificationType,
+		NotificationName: &notificationName,
+	}
+
+	response, err := client.ListNotifications(listOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CTS notification: %s", err)
+	}
+
+	if response.Notifications == nil || len(*response.Notifications) == 0 {
+		return nil, fmt.Errorf("can not find the CTS notification %s", notificationName)
+	}
+
+	allNotifications := *response.Notifications
+	ctsNotification := allNotifications[0]
+
+	return ctsNotification, nil
+}
+
+func TestAccCTSNotification_basic(t *testing.T) {
+	var notify cts.NotificationsResponseBody
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "sbercloud_cts_notification.notify"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&notify,
+		getCTSNotificationResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCTSNotification_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "operation_type", "complete"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttrPair(resourceName, "smn_topic",
+						"sbercloud_smn_topic.topic_1", "id"),
+				),
+			},
+			{
+				Config: testAccCTSNotification_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "operation_type", "customized"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "operations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "operations.0.service", "ECS"),
+					resource.TestCheckResourceAttrPair(resourceName, "smn_topic",
+						"sbercloud_smn_topic.topic_1", "id"),
+				),
+			},
+			{
+				Config: testAccCTSNotification_disable(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "operation_type", "customized"),
+					resource.TestCheckResourceAttr(resourceName, "status", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "operations.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCTSNotification_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_smn_topic" "topic_1" {
+  name  = "%[1]s"
+}
+
+resource "sbercloud_cts_notification" "notify" {
+  name           = "%[1]s"
+  operation_type = "complete"
+  smn_topic      = sbercloud_smn_topic.topic_1.id
+}
+`, rName)
+}
+
+func testAccCTSNotification_update(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_smn_topic" "topic_1" {
+  name  = "%[1]s"
+}
+
+resource "sbercloud_cts_notification" "notify" {
+  name           = "%[1]s"
+  operation_type = "customized"
+  smn_topic      = sbercloud_smn_topic.topic_1.id
+
+  operations {
+    service     = "ECS"
+    resource    = "ecs"
+    trace_names = ["createServer", "deleteServer"]
+  }
+}
+`, rName)
+}
+
+func testAccCTSNotification_disable(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_smn_topic" "topic_1" {
+  name  = "%[1]s"
+}
+
+resource "sbercloud_cts_notification" "notify" {
+  name           = "%[1]s"
+  operation_type = "customized"
+  smn_topic      = sbercloud_smn_topic.topic_1.id
+  enabled        = false
+
+  operations {
+    service     = "ECS"
+    resource    = "ecs"
+    trace_names = ["createServer", "deleteServer"]
+  }
+}
+`, rName)
+}

--- a/sbercloud/acceptance/cts/resource_sbercloud_cts_tracker_test.go
+++ b/sbercloud/acceptance/cts/resource_sbercloud_cts_tracker_test.go
@@ -1,0 +1,141 @@
+package cts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+)
+
+func TestAccCTSTracker_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "sbercloud_cts_tracker.tracker"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCTSTrackerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCTSTracker_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCTSTrackerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "file_prefix", "cts"),
+					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", "system"),
+					resource.TestCheckResourceAttr(resourceName, "type", "system"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+				),
+			},
+			{
+				Config: testAccCTSTracker_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "file_prefix", "cts-updated"),
+					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "status", "disabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCTSTrackerImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCTSTrackerImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		tracker, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("CTS tracker not found")
+		}
+
+		name := tracker.Primary.Attributes["name"]
+		if name == "" {
+			return "", fmt.Errorf("CTS tracker resource %s not found", tracker.Primary.ID)
+		}
+		return name, nil
+	}
+}
+
+func testAccCheckCTSTrackerDestroy(s *terraform.State) error {
+	// the system tracker always exists
+	return nil
+}
+
+func testAccCheckCTSTrackerExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		ctsClient, err := cfg.HcCtsV3Client(acceptance.SBC_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating CTS client: %s", err)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		listOpts := &cts.ListTrackersRequest{
+			TrackerName: &name,
+		}
+
+		response, err := ctsClient.ListTrackers(listOpts)
+		if err != nil {
+			return fmt.Errorf("error retrieving CTS tracker: %s", err)
+		}
+
+		if response.Trackers == nil || len(*response.Trackers) == 0 {
+			return fmt.Errorf("can not find the CTS tracker %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCTSTracker_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_obs_bucket" "bucket" {
+  bucket        = "%s"
+  acl           = "public-read"
+  force_destroy = true
+}
+
+resource "sbercloud_cts_tracker" "tracker" {
+  bucket_name = sbercloud_obs_bucket.bucket.bucket
+  file_prefix = "cts"
+  lts_enabled = true
+}
+`, rName)
+}
+
+func testAccCTSTracker_update(rName string) string {
+	return fmt.Sprintf(`
+resource "sbercloud_obs_bucket" "bucket" {
+  bucket        = "%s"
+  acl           = "public-read"
+  force_destroy = true
+}
+
+resource "sbercloud_cts_tracker" "tracker" {
+  bucket_name = sbercloud_obs_bucket.bucket.bucket
+  file_prefix = "cts-updated"
+  lts_enabled = false
+  enabled     = false
+}
+`, rName)
+}

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -1,6 +1,7 @@
 package sbercloud
 
 import (
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cts"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dew"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dns"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/nat"
@@ -251,6 +252,9 @@ func Provider() *schema.Provider {
 			"sbercloud_compute_eip_associate":           ecs.ResourceComputeEIPAssociate(),
 			"sbercloud_compute_volume_attach":           ecs.ResourceComputeVolumeAttach(),
 			"sbercloud_ces_alarmrule":                   ces.ResourceAlarmRule(),
+			"sbercloud_cts_tracker":                     cts.ResourceCTSTracker(),
+			"sbercloud_cts_data_tracker":                cts.ResourceCTSDataTracker(),
+			"sbercloud_cts_notification":                cts.ResourceCTSNotification(),
 			"sbercloud_dcs_instance":                    dcs.ResourceDcsInstance(),
 			"sbercloud_dds_instance":                    dds.ResourceDdsInstanceV3(),
 			"sbercloud_dis_stream":                      dis.ResourceDisStream(),


### PR DESCRIPTION
# What this PR does / why we need it:
Added resources:

- `cts_tracker`
- `cts_data_tracker`
- `cts_notification`

# Which issue this PR fixes:
Manage Cloud Trace Service with terraform

# PR Checklist

- [x] Tests added/passed.
- [x] Documentation updated.
- [x] Schema updated.

# Acceptance Steps Performed

```
TF_ACC=1 go test ./sbercloud/acceptance/cts -v -run TestAccCTSDataTracker_basic -timeout 360m -parallel=4
=== RUN   TestAccCTSDataTracker_basic
=== PAUSE TestAccCTSDataTracker_basic
=== CONT  TestAccCTSDataTracker_basic
--- PASS: TestAccCTSDataTracker_basic (10.78s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance/cts    10.788s

TF_ACC=1 go test ./sbercloud/acceptance/cts -v -run TestAccCTSNotification_basic -timeout 3
60m -parallel=4
=== RUN   TestAccCTSNotification_basic
=== PAUSE TestAccCTSNotification_basic
=== CONT  TestAccCTSNotification_basic
--- PASS: TestAccCTSNotification_basic (12.45s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance/cts    12.462s

TF_ACC=1 go test ./sbercloud/acceptance/cts -v -run TestAccCTSTracker_basic -timeout 360m -
parallel=4
=== RUN   TestAccCTSTracker_basic
=== PAUSE TestAccCTSTracker_basic
=== CONT  TestAccCTSTracker_basic
--- PASS: TestAccCTSTracker_basic (9.88s)
PASS
ok      github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance/cts    9.893s
