### PR TITLE
Add VPC objects

### DIFF
--- a/docs/data-sources/vpc_eips.md
+++ b/docs/data-sources/vpc_eips.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# sbercloud_vpc_eips
+
+Use this data source to get a list of EIPs.
+
+## Example Usage
+
+An example filter by name and tag
+
+```hcl
+variable "public_ip" {}
+
+data "sbercloud_vpc_eips" "eip" {
+  public_ips = [var.public_ip]
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+output "eip_ids" {
+  value = data.sbercloud_vpc_eips.eip.eips[*].id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available EIPs in the current region.
+All EIPs that meet the filter criteria will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain the EIP. If omitted, the provider-level region
+  will be used.
+
+* `ids` - (Optional, List) Specifies an array of one or more IDs of the desired EIP.
+
+* `public_ips` - (Optional, List) Specifies an array of one or more public ip addresses of the desired EIP.
+
+* `port_ids` - (Optional, List) Specifies an array of one or more port ids which bound to the desired EIP.
+
+* `ip_version` - (Optional, Int) Specifies ip version of the desired EIP. The options are:
+    + `4`: IPv4.
+    + `6`: IPv6.
+
+  The default value is `4`.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID which the desired EIP belongs to.
+
+* `tags` - (Optional, Map) Specifies the included key/value pairs which associated with the desired EIP.
+
+-> A maximum of 10 tag keys are allowed for each query operation. Each tag key can have up to 10 tag values.
+The tag key cannot be left blank or set to an empty string. Each tag key must be unique, and each tag value in a
+tag must be unique, use commas(,) to separate the multiple values. An empty for values indicates any value.
+The values are in the OR relationship.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `eips` - Indicates a list of all EIPs found. Structure is documented below.
+
+The `eips` block supports:
+
+* `id` - The ID of the EIP.
+* `name` - The name of the EIP.
+* `public_ip` - The public ip address of the EIP.
+* `private_ip` - The private ip address of the EIP.
+* `public_ipv6` - The public ipv6 address of the EIP.
+* `port_id` - The port id bound to the EIP.
+* `ip_version` - The ip version of the EIP.
+* `status` - The status of the EIP.
+* `type` - The type of the EIP.
+* `enterprise_project_id` - The the enterprise project ID of the EIP.
+* `bandwidth_id` - The bandwidth id of the EIP.
+* `bandwidth_name` - The bandwidth name of the EIP.
+* `bandwidth_size` - The bandwidth size of the EIP.
+* `bandwidth_share_type` - The bandwidth share type of the EIP.
+* `tags` - The key/value pairs which associated with the EIP.

--- a/sbercloud/provider.go
+++ b/sbercloud/provider.go
@@ -239,6 +239,7 @@ func Provider() *schema.Provider {
 			"sbercloud_vpcs":                   vpc.DataSourceVpcs(),
 			"sbercloud_vpc_bandwidth":          eip.DataSourceBandWidth(),
 			"sbercloud_vpc_eip":                eip.DataSourceVpcEip(),
+			"sbercloud_vpc_eips":               eip.DataSourceVpcEips(),
 			"sbercloud_vpc_ids":                vpc.DataSourceVpcIdsV1(),
 			"sbercloud_vpc_peering_connection": vpc.DataSourceVpcPeeringConnectionV2(),
 			"sbercloud_vpc_route":              vpc.DataSourceVpcRouteV2(),

--- a/sbercloud/vpc/data_source_sbercloud_vpc_eips_test.go
+++ b/sbercloud/vpc/data_source_sbercloud_vpc_eips_test.go
@@ -1,0 +1,96 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVpcEipsDataSource_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.sbercloud_vpc_eips.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcEips_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.status", "UNBOUND"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.ip_version", "4"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_share_type", "PER"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.key", "value"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "eips.0.id",
+						"sbercloud_vpc_eip.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcEips_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_vpc_eips" "test" {
+  public_ips = [sbercloud_vpc_eip.test.address]
+}
+`, testAccVpcEip_tags(rName))
+}
+
+func TestAccVpcEipsDataSource_byTag(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.sbercloud_vpc_eips.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcEips_byTag(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.status", "UNBOUND"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.ip_version", "4"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_share_type", "PER"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.key", "value"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "eips.0.id",
+						"sbercloud_vpc_eip.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcEips_byTag(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "sbercloud_vpc_eips" "test" {
+  public_ips = [sbercloud_vpc_eip.test.address]
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testAccVpcEip_tags(rName))
+}

--- a/sbercloud/vpc/resource_sbercloud_vpc_eip_test.go
+++ b/sbercloud/vpc/resource_sbercloud_vpc_eip_test.go
@@ -153,6 +153,7 @@ resource "sbercloud_vpc_eip" "test" {
 func testAccVpcEip_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "sbercloud_vpc_eip" "test" {
+	name        = "%s"
   publicip {
     type = "5_bgp"
   }
@@ -167,7 +168,7 @@ resource "sbercloud_vpc_eip" "test" {
     key = "value"
   }
 }
-`, rName)
+`, rName, rName)
 }
 
 func testAccVpcEip_epsId(rName string) string {


### PR DESCRIPTION
# What this PR does / why we need it:
Added data sources:

`vpc_eips`

# Which issue this PR fixes:
This data source provides to get a list of EIPs.

# PR Checklist

- [x] Tests added/passed.
- [x] Documentation updated.
- [x] Schema updated.

# Acceptance Steps Performed
```
TF_ACC=1 go test ./sbercloud/vpc -v -run TestAccVpcEipsDataSource_byTag -timeout 360m -parallel=4
=== RUN   TestAccVpcEipsDataSource_byTag
=== PAUSE TestAccVpcEipsDataSource_byTag
=== CONT  TestAccVpcEipsDataSource_byTag
--- PASS: TestAccVpcEipsDataSource_byTag (18.57s)
PASS
ok  	github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/vpc	18.578s


TF_ACC=1 go test ./sbercloud/vpc -v -run TestAccVpcEipsDataSource_basic -timeout 360m -parallel=4
=== RUN   TestAccVpcEipsDataSource_basic
=== PAUSE TestAccVpcEipsDataSource_basic
=== CONT  TestAccVpcEipsDataSource_basic
--- PASS: TestAccVpcEipsDataSource_basic (18.52s)
PASS
ok  	github.com/sbercloud-terraform/terraform-provider-sbercloud/sbercloud/vpc	18.528s